### PR TITLE
Added a script to Clean Java Version on Ubuntu

### DIFF
--- a/static/Clean_Java_And_Launch_VoxelShop-Ubuntu.sh
+++ b/static/Clean_Java_And_Launch_VoxelShop-Ubuntu.sh
@@ -1,0 +1,14 @@
+#First check previous version of java
+java -version
+
+#Remove all versions of java
+sudo apt-get purge --auto-remove openjdk*
+
+#Check again, this check should fail
+java -version
+
+#Install the correct version for Voxelshop
+sudo apt install openjdk-8-jdk openjdk-8-jre
+
+#And launch program
+java -jar voxelshop-start.jar


### PR DESCRIPTION
Added a script for Ubuntu based systems, that purges every other java versions installed and installs Openjdk 8, which is the version which works best with VoxelShop.